### PR TITLE
FIX: Don't assume SS4 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,8 +13,8 @@
     "require": {
         "php"                                   : ">=5.3.0",
         "composer/installers"                   : ">=1.0",
-        "silverstripe/framework"                : ">=3.1",
-        "silverstripe/cms"                      : ">=3.1",
+        "silverstripe/framework"                : "^3.1",
+        "silverstripe/cms"                      : "^3.1",
         "micschk/silverstripe-excludechildren"  : "1.1.*@stable"
     }
 }


### PR DESCRIPTION
Major versions won't automatically work, and so I've amended the composer requirements
not to allow SS4.

This will also ensure that addons.silverstripe.org correctly reports which modules
work with SS4.